### PR TITLE
AP mode freeze fix

### DIFF
--- a/core/rtw_ap.c
+++ b/core/rtw_ap.c
@@ -741,7 +741,11 @@ void	expire_timeout_chk(_adapter *padapter)
 
 			RTW_INFO(FUNC_ADPT_FMT" asoc expire "MAC_FMT", state=0x%x\n"
 				, FUNC_ADPT_ARG(padapter), MAC_ARG(psta->cmn.mac_addr), psta->state);
+			#ifdef CONFIG_ACTIVE_KEEP_ALIVE_CHECK
 			updated |= ap_free_sta(padapter, psta, _FALSE, WLAN_REASON_DEAUTH_LEAVING, _FALSE);
+			#else
+			updated |= ap_free_sta(padapter, psta, _FALSE, WLAN_REASON_DEAUTH_LEAVING, _TRUE);
+			#endif
 			#ifdef CONFIG_RTW_MESH
 			if (MLME_IS_MESH(padapter))
 				rtw_mesh_expire_peer(padapter, sta_addr);


### PR DESCRIPTION
This seems to solve the random freezes of the entire system in AP mode.

This fix allows for a much better stability of the system, at least for me (it has been running for a couple of days now without a kernel freeze, when previously the computer stopped working after a couple hours and some client connections/disconnections).

This is inspired by [this](https://github.com/aircrack-ng/rtl8812au/issues/625) issue for the similar RTL8812AU driver.

I've tested it with an Alfa AWUS1900. Please feel free to try it with some other adapters, as I do not have any more with this chipset laying around.