### PR TITLE
set GCC to -O3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 EXTRA_CFLAGS += $(USER_EXTRA_CFLAGS)
-EXTRA_CFLAGS += -O1
-#EXTRA_CFLAGS += -O3
+#EXTRA_CFLAGS += -O1
+EXTRA_CFLAGS += -O3
 #EXTRA_CFLAGS += -Wall
 #EXTRA_CFLAGS += -Wextra
 EXTRA_CFLAGS += -Wno-error
@@ -25,7 +25,7 @@ endif
 
 EXTRA_CFLAGS += -I$(src)/include
 
-EXTRA_LDFLAGS += --strip-debug
+EXTRA_LDFLAGS += --strip-all -O3
 
 CONFIG_AUTOCFG_CP = n
 


### PR DESCRIPTION
increase GCC compile optimization to -O3 and set linker to omit all symbol information from the output file.