### PR TITLE
fix: build warning

### DIFF
--- a/core/mesh/rtw_mesh.c
+++ b/core/mesh/rtw_mesh.c
@@ -3082,7 +3082,7 @@ void rtw_mesh_init_mesh_info(_adapter *adapter)
 
 	_rtw_init_queue(&minfo->mpath_tx_queue);
 	tasklet_init(&minfo->mpath_tx_tasklet
-		, (void(*)(unsigned long))mpath_tx_tasklet_hdl
+		, (void(*))mpath_tx_tasklet_hdl
 		, (unsigned long)adapter);
 
 	rtw_mrc_init(adapter);

--- a/hal/hal_hci/hal_usb.c
+++ b/hal/hal_hci/hal_usb.c
@@ -25,7 +25,7 @@ int	usb_init_recv_priv(_adapter *padapter, u16 ini_in_buf_sz)
 
 #ifdef PLATFORM_LINUX
 	tasklet_init(&precvpriv->recv_tasklet,
-		     (void(*)(unsigned long))usb_recv_tasklet,
+		     (void(*))usb_recv_tasklet,
 		     (unsigned long)padapter);
 #endif /* PLATFORM_LINUX */
 

--- a/hal/rtl8814a/usb/rtl8814au_xmit.c
+++ b/hal/rtl8814a/usb/rtl8814au_xmit.c
@@ -25,7 +25,7 @@ s32	rtl8814au_init_xmit_priv(_adapter *padapter)
 
 #ifdef PLATFORM_LINUX
 	tasklet_init(&pxmitpriv->xmit_tasklet,
-		     (void(*)(unsigned long))rtl8814au_xmit_tasklet,
+		     (void(*))rtl8814au_xmit_tasklet,
 		     (unsigned long)padapter);
 #endif
 #ifdef CONFIG_TX_EARLY_MODE


### PR DESCRIPTION
  warning: cast between incompatible function types from ‘void (*)(void )’ to ‘void ()(long unsigned int)’